### PR TITLE
automatically create text index on startup

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 spring.data.mongodb.uri=${SIC_CODE_API_MONGO_URL}
 spring.data.mongodb.database=${SIC_CODE_API_DATABASE}
+
+# For team and citest environments where we create the database via mongo import, need Spring to automatically create test index
+spring.data.mongodb.auto-index-creation=true


### PR DESCRIPTION
__Short description outlining key changes/additions__
Get Spring to automatically create the Text Index on the combined_sic_activities if it does not exist when starting up (this is important in the AWS test environments where we use concourse to import the data).

Tested this by:
- dropping the text index
- starting up the app
- checked that the text index was recreated

__JIRA Ticket Number__
n/a

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__
