### PR TITLE
Revert "automatically create text index on startup"

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,2 @@
 spring.data.mongodb.uri=${SIC_CODE_API_MONGO_URL}
 spring.data.mongodb.database=${SIC_CODE_API_DATABASE}
-
-# For team and citest environments where we create the database via mongo import, need Spring to automatically create test index
-spring.data.mongodb.auto-index-creation=true


### PR DESCRIPTION
Reverts companieshouse/sic-code-api#7

This PR would require us matching what Spring generates for a repository to match the create index script and might cause problems with our concourse builds